### PR TITLE
Add profile overview with dashboard stats

### DIFF
--- a/src/pages/nfts/profile/[accountAddress]/overview.tsx
+++ b/src/pages/nfts/profile/[accountAddress]/overview.tsx
@@ -1,0 +1,10 @@
+import { NftProfileLayout } from 'views/Nft/market/Profile'
+import ProfileOverview from 'views/Nft/market/Profile/components/Overview'
+
+const NftProfileOverviewPage = () => {
+  return <ProfileOverview />
+}
+
+NftProfileOverviewPage.Layout = NftProfileLayout
+
+export default NftProfileOverviewPage

--- a/src/views/Nft/market/Profile/components/Overview/index.tsx
+++ b/src/views/Nft/market/Profile/components/Overview/index.tsx
@@ -1,0 +1,89 @@
+import { AutoRenewIcon, Box, Button, Card, CardBody, Flex, Heading, Text } from '@pancakeswap/uikit'
+import { useRouter } from 'next/router'
+import { useTranslation } from 'contexts/Localization'
+import StatBox, { StatBoxItem } from 'views/Nft/market/components/StatBox'
+import { formatNumber, getBalanceNumber } from 'utils/formatBalance'
+import { BIG_ZERO } from 'utils/bigNumber'
+import useProfileDashboardData from '../../hooks/useProfileDashboardData'
+
+const ProfileOverview = () => {
+  const { t } = useTranslation()
+  const { query } = useRouter()
+  const accountAddress = typeof query.accountAddress === 'string' ? query.accountAddress : undefined
+  const dashboardData = useProfileDashboardData(accountAddress)
+
+  const totalPendingRewards = dashboardData.pendingRewards ?? BIG_ZERO
+  const pendingRewardsStat = dashboardData.isLoading
+    ? null
+    : dashboardData.pendingRewards == null
+    ? '-'
+    : `${formatNumber(getBalanceNumber(totalPendingRewards, 18), 2, 2)} COLLECT`
+
+  const totalStakedBalance = dashboardData.stakedBalance ?? BIG_ZERO
+  const stakedNftsStat = dashboardData.isLoading
+    ? null
+    : dashboardData.stakedBalance == null
+    ? '-'
+    : formatNumber(totalStakedBalance.toNumber(), 0, 0)
+
+  const isOwnProfile = typeof dashboardData.onHarvestAll === 'function'
+  const harvestDisabled =
+    dashboardData.isLoading || dashboardData.isHarvestingAll || !dashboardData.canHarvest
+
+  const stats = [
+    { title: t('Pending rewards'), stat: pendingRewardsStat },
+    { title: t('Staked NFTs'), stat: stakedNftsStat },
+  ]
+
+  return (
+    <Flex flexDirection="column" gridGap="24px">
+      <Card>
+        <CardBody>
+          <Heading scale="md">{t('Profile overview')}</Heading>
+          <Text color="textSubtle" mt="8px">
+            {isOwnProfile
+              ? t('Review your aggregated staking activity and pending rewards across CoinCollect NFT farms.')
+              : t('Overview metrics are available when you connect the wallet that owns this profile.')}
+          </Text>
+        </CardBody>
+      </Card>
+      <StatBox>
+        {stats.map((item) => (
+          <StatBoxItem key={item.title} title={item.title} stat={item.stat} />
+        ))}
+      </StatBox>
+      {isOwnProfile && (
+        <Card>
+          <CardBody>
+            <Flex
+              flexDirection={['column', null, 'row']}
+              alignItems={['flex-start', null, 'center']}
+              justifyContent="space-between"
+              gridGap="16px"
+            >
+              <Box>
+                <Heading scale="sm">{t('Harvest all pending rewards')}</Heading>
+                <Text color="textSubtle" mt="8px">
+                  {dashboardData.canHarvest
+                    ? t('Collect rewards from all of your active NFT farms in a single transaction.')
+                    : t('You do not have any pending rewards to harvest right now.')}
+                </Text>
+              </Box>
+              <Button
+                width={['100%', null, 'auto']}
+                onClick={() => dashboardData.onHarvestAll?.()}
+                disabled={harvestDisabled}
+                isLoading={dashboardData.isHarvestingAll}
+                endIcon={dashboardData.isHarvestingAll ? <AutoRenewIcon spin color="currentColor" /> : null}
+              >
+                {dashboardData.isHarvestingAll ? t('Harvesting') : t('Harvest All Rewards')}
+              </Button>
+            </Flex>
+          </CardBody>
+        </Card>
+      )}
+    </Flex>
+  )
+}
+
+export default ProfileOverview

--- a/src/views/Nft/market/Profile/components/TabMenu.tsx
+++ b/src/views/Nft/market/Profile/components/TabMenu.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react'
 import { useTranslation } from 'contexts/Localization'
 import { NextLinkFromReactRouter } from 'components/NextLink'
 import styled from 'styled-components'
@@ -27,33 +26,32 @@ const Tab = styled.button<{ $active: boolean }>`
 const TabMenu = () => {
   const { t } = useTranslation()
   const { pathname, query } = useRouter()
-  const { accountAddress } = query
-  const [achievementsActive, setIsAchievementsActive] = useState(pathname.includes('achievements'))
+  const accountAddress = typeof query.accountAddress === 'string' ? query.accountAddress : ''
+  const profileBasePath = accountAddress ? `${nftsBaseUrl}/profile/${accountAddress}` : `${nftsBaseUrl}/profile`
+  const isOverview = pathname?.includes('/overview')
 
-  useEffect(() => {
-    setIsAchievementsActive(pathname.includes('achievements'))
-  }, [pathname])
+  const tabs = [
+    {
+      key: 'overview',
+      label: t('Overview'),
+      href: `${profileBasePath}/overview`,
+      isActive: isOverview,
+    },
+    {
+      key: 'nfts',
+      label: t('NFTs'),
+      href: profileBasePath,
+      isActive: !isOverview,
+    },
+  ]
 
   return (
     <Flex>
-      <Tab
-        onClick={() => setIsAchievementsActive(false)}
-        $active={!achievementsActive}
-        as={NextLinkFromReactRouter}
-        to={`${nftsBaseUrl}/profile/${accountAddress}`}
-      >
-        NFTs
-      </Tab>
-      {/* TODO: Activate later
-      <Tab
-        onClick={() => setIsAchievementsActive(true)}
-        $active={achievementsActive}
-        as={NextLinkFromReactRouter}
-        to={`${nftsBaseUrl}/profile/${accountAddress}/achievements`}
-      >
-        {t('Achievements')}
-      </Tab>
-    */}
+      {tabs.map((tab) => (
+        <Tab key={tab.key} $active={tab.isActive} as={NextLinkFromReactRouter} to={tab.href}>
+          {tab.label}
+        </Tab>
+      ))}
     </Flex>
   )
 }

--- a/src/views/Nft/market/Profile/hooks/useProfileDashboardData.ts
+++ b/src/views/Nft/market/Profile/hooks/useProfileDashboardData.ts
@@ -1,0 +1,135 @@
+import { useCallback, useMemo } from 'react'
+import BigNumber from 'bignumber.js'
+import useWeb3React from 'hooks/useWeb3React'
+import { useFarms, usePollFarmsWithUserData } from 'state/nftFarms/hooks'
+import { harvestNftFarm } from 'utils/calls'
+import { useCoinCollectNftStake } from 'hooks/useContract'
+import { useGasPrice } from 'state/user/hooks'
+import useCatchTxError from 'hooks/useCatchTxError'
+import { useAppDispatch } from 'state'
+import { fetchFarmUserDataAsync } from 'state/nftFarms'
+import { useTranslation } from 'contexts/Localization'
+import useToast from 'hooks/useToast'
+import { ToastDescriptionWithTx } from 'components/Toast'
+import { BIG_ZERO } from 'utils/bigNumber'
+import { getSmartNftStakeContract } from 'utils/contractHelpers'
+import { DeserializedNftFarm } from 'state/types'
+
+export interface ProfileDashboardData {
+  pendingRewards?: BigNumber | null
+  stakedBalance?: BigNumber | null
+  isLoading: boolean
+  onHarvestAll?: () => Promise<void>
+  isHarvestingAll: boolean
+  canHarvest: boolean
+}
+
+const useProfileDashboardData = (accountAddress?: string): ProfileDashboardData => {
+  const { account, library } = useWeb3React()
+  const isConnectedAccount = Boolean(
+    account && accountAddress && account.toLowerCase() === accountAddress.toLowerCase(),
+  )
+
+  usePollFarmsWithUserData()
+  const { data: farms, userDataLoaded } = useFarms()
+  const coinCollectNftStakeContract = useCoinCollectNftStake()
+  const gasPrice = useGasPrice()
+  const { fetchWithCatchTxError, loading: isHarvestingAll } = useCatchTxError()
+  const dispatch = useAppDispatch()
+  const { t } = useTranslation()
+  const { toastSuccess } = useToast()
+
+  const { pendingRewards, stakedBalance, harvestableFarms } = useMemo(() => {
+    if (!isConnectedAccount) {
+      return {
+        pendingRewards: null,
+        stakedBalance: null,
+        harvestableFarms: [] as DeserializedNftFarm[],
+      }
+    }
+
+    let totalPending = new BigNumber(0)
+    let totalStaked = new BigNumber(0)
+    const farmsWithRewards: DeserializedNftFarm[] = []
+
+    farms.forEach((farm) => {
+      const earnings = farm?.userData?.earnings ?? BIG_ZERO
+      const staked = farm?.userData?.stakedBalance ?? BIG_ZERO
+
+      totalPending = totalPending.plus(earnings)
+      totalStaked = totalStaked.plus(staked)
+
+      if (earnings.gt(0)) {
+        farmsWithRewards.push(farm)
+      }
+    })
+
+    return {
+      pendingRewards: totalPending,
+      stakedBalance: totalStaked,
+      harvestableFarms: farmsWithRewards,
+    }
+  }, [farms, isConnectedAccount])
+
+  const handleHarvestAll = useCallback(async () => {
+    if (!isConnectedAccount || harvestableFarms.length === 0 || !account) {
+      return
+    }
+
+    const pids: number[] = []
+
+    for (const farm of harvestableFarms) {
+      const isSmartPool = Boolean(farm.contractAddresses)
+      const contract = isSmartPool
+        ? library
+          ? getSmartNftStakeContract(farm.pid, library.getSigner())
+          : null
+        : coinCollectNftStakeContract
+
+      if (!contract) {
+        continue
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const receipt = await fetchWithCatchTxError(() =>
+        harvestNftFarm(contract, farm.pid, gasPrice, isSmartPool),
+      )
+
+      if (receipt?.status) {
+        toastSuccess(
+          `${t('Harvested')}!`,
+          <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+            {t('Your %symbol% earnings have been sent to your wallet!', { symbol: 'COLLECT' })}
+          </ToastDescriptionWithTx>,
+        )
+        pids.push(farm.pid)
+      }
+    }
+
+    if (pids.length > 0) {
+      dispatch(fetchFarmUserDataAsync({ account, pids }))
+    }
+  }, [
+    account,
+    coinCollectNftStakeContract,
+    dispatch,
+    fetchWithCatchTxError,
+    gasPrice,
+    harvestableFarms,
+    isConnectedAccount,
+    library,
+    toastSuccess,
+    t,
+  ])
+
+  return {
+    pendingRewards,
+    stakedBalance,
+    isLoading: isConnectedAccount ? !userDataLoaded : false,
+    onHarvestAll: isConnectedAccount ? handleHarvestAll : undefined,
+    isHarvestingAll,
+    canHarvest: isConnectedAccount && harvestableFarms.length > 0,
+  }
+}
+
+export default useProfileDashboardData

--- a/src/views/Nft/market/Profile/index.tsx
+++ b/src/views/Nft/market/Profile/index.tsx
@@ -11,6 +11,7 @@ import ProfileHeader from './components/ProfileHeader'
 import NoNftsImage from '../components/Activity/NoNftsImage'
 import useNftsForAddress from '../hooks/useNftsForAddress'
 import TabMenu from './components/TabMenu'
+import useProfileDashboardData from './hooks/useProfileDashboardData'
 
 const TabMenuWrapper = styled(Box)`
   position: absolute;
@@ -46,6 +47,7 @@ const NftProfile: FC = ({ children }) => {
     isLoading: isNftLoading,
     refresh: refreshUserNfts,
   } = useNftsForAddress(accountAddress, profile, isProfileValidating)
+  const dashboardData = useProfileDashboardData(invalidAddress ? undefined : accountAddress)
 
   if (invalidAddress) {
     return (
@@ -88,6 +90,7 @@ const NftProfile: FC = ({ children }) => {
             await refreshProfile()
             refreshUserNfts()
           }}
+          dashboardData={dashboardData}
         />
         <TabMenuWrapper>
           <TabMenu />

--- a/src/views/Nft/market/components/StatBox.tsx
+++ b/src/views/Nft/market/components/StatBox.tsx
@@ -1,17 +1,18 @@
+import { ReactNode } from 'react'
 import styled from 'styled-components'
 import { Box, BoxProps, Flex, Skeleton, Text } from '@pancakeswap/uikit'
 
 export interface StatBoxItemProps extends BoxProps {
   title: string
-  stat: string
+  stat?: ReactNode | null
 }
 
 export const StatBoxItem: React.FC<StatBoxItemProps> = ({ title, stat, ...props }) => (
-  <Box {...props}>
+  <Box flex="1 1 120px" minWidth="120px" {...props}>
     <Text fontSize="12px" color="textSubtle" textAlign="center">
       {title}
     </Text>
-    {stat === null ? (
+    {stat === null || stat === undefined ? (
       <Skeleton height="24px" width="50%" mx="auto" />
     ) : (
       <Text fontWeight="600" textAlign="center">
@@ -22,13 +23,20 @@ export const StatBoxItem: React.FC<StatBoxItemProps> = ({ title, stat, ...props 
 )
 
 const StatBox = styled(Flex)`
-  align-items: center;
+  align-items: stretch;
   background: ${({ theme }) => theme.colors.invertedContrast};
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};
   border-radius: ${({ theme }) => theme.radii.card};
-  justify-content: space-around;
-  padding: 8px;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+  padding: 16px;
   width: 100%;
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    gap: 24px;
+    justify-content: space-between;
+  }
 `
 
 export default StatBox


### PR DESCRIPTION
## Summary
- restore profile header statistics and add pending rewards plus harvest controls wired to new dashboard data
- introduce a reusable profile dashboard hook alongside an overview tab and page that surface staking metrics
- update stat box styling to accommodate the expanded metrics and remain responsive

## Testing
- yarn lint *(fails: missing @pancakeswap/eslint-config-pancake)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2c1c4e8883219ba01d189d6efeb2