### PR TITLE
feat: add profile overview for staking positions

### DIFF
--- a/src/pages/nfts/profile/[accountAddress].tsx
+++ b/src/pages/nfts/profile/[accountAddress].tsx
@@ -28,9 +28,7 @@ const NftProfilePage = () => {
   
   return (
     <>
-      {/* TODO: Activate Later
       <SubMenu />
-      */}
       {isConnectedProfile ? (
         <UserNfts
           nfts={nfts}

--- a/src/pages/nfts/profile/[accountAddress]/overview.tsx
+++ b/src/pages/nfts/profile/[accountAddress]/overview.tsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/router'
+import { NftProfileLayout } from 'views/Nft/market/Profile'
+import SubMenu from 'views/Nft/market/Profile/components/SubMenu'
+import ProfileOverview from 'views/Nft/market/Profile/components/Overview'
+
+const NftProfileOverviewPage = () => {
+  const { query } = useRouter()
+  const accountAddress = query.accountAddress as string
+
+  return (
+    <>
+      <SubMenu />
+      <ProfileOverview accountAddress={accountAddress} />
+    </>
+  )
+}
+
+NftProfileOverviewPage.Layout = NftProfileLayout
+
+export default NftProfileOverviewPage

--- a/src/views/Farms/components/FarmCard/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmCard/HarvestAction.tsx
@@ -19,9 +19,10 @@ import useAnimatedRewardValue from 'hooks/useAnimatedRewardValue'
 interface FarmCardActionsProps {
   earnings?: BigNumber
   pid?: number
+  onHarvestSuccess?: () => void
 }
 
-const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid }) => {
+const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid, onHarvestSuccess }) => {
   const { account } = useWeb3React()
   const { toastSuccess } = useToast()
   const { fetchWithCatchTxError, loading: pendingTx } = useCatchTxError()
@@ -57,6 +58,7 @@ const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid }) => {
               </ToastDescriptionWithTx>,
             )
             dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
+            onHarvestSuccess?.()
           }
         }}
       >

--- a/src/views/Nft/market/Profile/components/Overview/PendingRewardsCard.tsx
+++ b/src/views/Nft/market/Profile/components/Overview/PendingRewardsCard.tsx
@@ -1,0 +1,84 @@
+import styled from 'styled-components'
+import { Card, CardBody, CardHeader, Flex, Heading, Skeleton, Tag, Text } from '@pancakeswap/uikit'
+import { useTranslation } from 'contexts/Localization'
+import { formatNumber, getBalanceNumber } from 'utils/formatBalance'
+import { RewardBreakdownEntry } from '../../hooks/useProfileDefiOverview'
+
+const StyledCard = styled(Card)`
+  margin-bottom: 24px;
+`;
+
+const Badge = styled(Tag)`
+  margin-right: 8px;
+  margin-bottom: 8px;
+`;
+
+interface PendingRewardsCardProps {
+  breakdown: RewardBreakdownEntry[]
+  positionsCount: number
+  isAccountMatch: boolean
+  isLoading: boolean
+}
+
+const PendingRewardsCard: React.FC<PendingRewardsCardProps> = ({ breakdown, positionsCount, isAccountMatch, isLoading }) => {
+  const { t } = useTranslation()
+
+  if (!isAccountMatch) {
+    return null
+  }
+
+  if (isLoading) {
+    return (
+      <StyledCard>
+        <CardHeader>
+          <Heading scale="md">{t('Pending rewards')}</Heading>
+        </CardHeader>
+        <CardBody>
+          <Skeleton height="120px" width="100%" />
+        </CardBody>
+      </StyledCard>
+    )
+  }
+
+  const totals = breakdown.map((entry) => ({
+    token: entry.token,
+    amount: getBalanceNumber(entry.amount, entry.decimals),
+  }))
+
+  const totalValue = totals.reduce((accum, entry) => accum + entry.amount, 0)
+
+  return (
+    <StyledCard>
+      <CardHeader>
+        <Heading scale="md">{t('Pending rewards')}</Heading>
+      </CardHeader>
+      <CardBody>
+        <Flex justifyContent="space-between" alignItems="center" mb="16px" flexWrap="wrap">
+          <Text color="textSubtle">{t('Active positions')}</Text>
+          <Heading scale="lg">{positionsCount}</Heading>
+        </Flex>
+        <Flex flexDirection="column">
+          <Text color="textSubtle" fontSize="12px" mb="8px">
+            {t('Reward breakdown')}
+          </Text>
+          <Flex flexWrap="wrap">
+            {totals.length === 0 ? (
+              <Text color="textSubtle">{t('No pending rewards')}</Text>
+            ) : (
+              totals.map((entry) => {
+                const percentage = totalValue > 0 ? (entry.amount / totalValue) * 100 : 0
+                return (
+                  <Badge key={entry.token} variant="secondary">
+                    {`${entry.token}: ${formatNumber(entry.amount, 0, 4)} (${percentage.toFixed(1)}%)`}
+                  </Badge>
+                )
+              })
+            )}
+          </Flex>
+        </Flex>
+      </CardBody>
+    </StyledCard>
+  )
+}
+
+export default PendingRewardsCard

--- a/src/views/Nft/market/Profile/components/Overview/StakedPositionsPanel.tsx
+++ b/src/views/Nft/market/Profile/components/Overview/StakedPositionsPanel.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useMemo } from 'react'
+import styled from 'styled-components'
+import BigNumber from 'bignumber.js'
+import {
+  Box,
+  Card,
+  CardBody,
+  CardHeader,
+  Flex,
+  Heading,
+  Link,
+  Skeleton,
+  Tag,
+  Text,
+  Button,
+  useModal,
+} from '@pancakeswap/uikit'
+import { NextLinkFromReactRouter } from 'components/NextLink'
+import { formatNumber, getBalanceNumber, getFullDisplayBalance } from 'utils/formatBalance'
+import { useTranslation } from 'contexts/Localization'
+import HarvestAction from 'views/NftFarms/components/FarmCard/HarvestAction'
+import FarmHarvestAction from 'views/Farms/components/FarmCard/HarvestAction'
+import CollectModal from 'views/Pools/components/PoolCard/Modals/CollectModal'
+import { OverviewCategory, OverviewPosition, OverviewRefreshers } from '../../hooks/useProfileDefiOverview'
+
+const StyledCard = styled(Card)`
+  margin-bottom: 24px;
+`;
+
+const PositionRow = styled(Flex)`
+  flex-direction: column;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.cardBorder};
+  padding: 16px 0;
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const PositionHeader = styled(Flex)`
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-direction: column;
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    flex-direction: row;
+    align-items: center;
+  }
+`;
+
+const MetricsContainer = styled(Flex)`
+  flex-wrap: wrap;
+  margin-top: 12px;
+  gap: 12px;
+`;
+
+const Metric = styled(Flex)`
+  flex-direction: column;
+  min-width: 120px;
+`;
+
+interface StakedPositionsPanelProps {
+  categories: OverviewCategory[]
+  isAccountMatch: boolean
+  isLoading: boolean
+  refreshers: OverviewRefreshers
+}
+
+const formatStakeAmount = (amount: BigNumber, decimals: number) => {
+  const value = getBalanceNumber(amount, decimals)
+  if (value === 0) {
+    return '0'
+  }
+  if (value < 0.01) {
+    return value.toFixed(4)
+  }
+  return formatNumber(value, 0, 2)
+}
+
+const PositionActions: React.FC<{ position: OverviewPosition; refreshers: OverviewRefreshers }> = ({ position, refreshers }) => {
+  const { t } = useTranslation()
+
+  const handleSuccess = useCallback(async () => {
+    switch (position.type) {
+      case 'nftFarm':
+        await refreshers.nftFarms()
+        break
+      case 'liquidityFarm':
+        await refreshers.liquidityFarms()
+        break
+      case 'pool':
+        await refreshers.pools()
+        break
+      case 'vault':
+        await refreshers.vaults()
+        break
+      default:
+        break
+    }
+  }, [position.type, refreshers])
+
+  if (position.type === 'nftFarm') {
+    return (
+      <HarvestAction
+        earnings={position.pendingRewards[0]?.amount}
+        pid={position.pid}
+        earnLabel={position.earningTokenSymbol}
+        sideRewards={position.sideRewards ?? []}
+        earningToken={position.earningToken}
+        onHarvestSuccess={handleSuccess}
+      />
+    )
+  }
+
+  if (position.type === 'liquidityFarm') {
+    return <FarmHarvestAction earnings={position.pendingRewards[0]?.amount} pid={position.pid} onHarvestSuccess={handleSuccess} />
+  }
+
+  const pendingReward = position.pendingRewards[0]
+  const formattedBalance = pendingReward
+    ? formatNumber(getBalanceNumber(pendingReward.amount, pendingReward.decimals), 0, 5)
+    : '0'
+  const fullBalance = pendingReward ? getFullDisplayBalance(pendingReward.amount, pendingReward.decimals) : '0'
+  const hasPending = Boolean(pendingReward && !pendingReward.amount.isZero())
+
+  const [onPresentCollect] = useModal(
+    <CollectModal
+      formattedBalance={formattedBalance}
+      fullBalance={fullBalance}
+      earningToken={position.earningToken}
+      earningsDollarValue={0}
+      sousId={position.sousId ?? 0}
+      isBnbPool={false}
+      isCompoundPool={position.type === 'vault'}
+      onTxSuccess={handleSuccess}
+    />,
+  )
+
+  return (
+    <Flex justifyContent="flex-end">
+      <Button onClick={onPresentCollect} disabled={!hasPending || !position.earningToken} variant="secondary">
+        {position.type === 'vault' ? t('Compound / Harvest') : t('Harvest')}
+      </Button>
+    </Flex>
+  )
+}
+
+const PositionDetails: React.FC<{ position: OverviewPosition; refreshers: OverviewRefreshers }> = ({ position, refreshers }) => {
+  const { t } = useTranslation()
+  const aprText = position.aprLabel ?? (position.apr ? `${position.apr}` : t('N/A'))
+  const stakedText = formatStakeAmount(position.staked, position.stakedDecimals)
+  const pendingToken = position.pendingRewards[0]
+  const pendingDisplay = pendingToken
+    ? `${formatStakeAmount(pendingToken.amount, pendingToken.decimals)} ${pendingToken.token}`
+    : t('N/A')
+
+  return (
+    <PositionRow>
+      <PositionHeader>
+        <Box>
+          {position.href ? (
+            <Link as={NextLinkFromReactRouter} to={position.href} color="primary" bold>
+              {position.label}
+            </Link>
+          ) : (
+            <Heading scale="md">{position.label}</Heading>
+          )}
+          <Tag variant="secondary" mt="8px">
+            {position.type === 'nftFarm'
+              ? t('NFT Farm')
+              : position.type === 'liquidityFarm'
+              ? t('Liquidity Farm')
+              : position.type === 'vault'
+              ? t('Vault')
+              : t('Pool')}
+          </Tag>
+        </Box>
+        <Box mt="12px" width="100%">
+          <PositionActions position={position} refreshers={refreshers} />
+        </Box>
+      </PositionHeader>
+      <MetricsContainer>
+        <Metric>
+          <Text color="textSubtle" fontSize="12px">
+            {t('Staked')}
+          </Text>
+          <Heading scale="sm">{stakedText}</Heading>
+        </Metric>
+        <Metric>
+          <Text color="textSubtle" fontSize="12px">
+            {t('Pending rewards')}
+          </Text>
+          <Heading scale="sm">{pendingDisplay}</Heading>
+        </Metric>
+        <Metric>
+          <Text color="textSubtle" fontSize="12px">
+            {t('APR')}
+          </Text>
+          <Heading scale="sm">{aprText}</Heading>
+        </Metric>
+      </MetricsContainer>
+    </PositionRow>
+  )
+}
+
+const StakedPositionsPanel: React.FC<StakedPositionsPanelProps> = ({ categories, isAccountMatch, isLoading, refreshers }) => {
+  const { t } = useTranslation()
+  const visibleCategories = useMemo(() => categories.filter((category) => category.positions.length > 0), [categories])
+
+  if (!isAccountMatch) {
+    return (
+      <StyledCard>
+        <CardBody>
+          <Text>{t('Connect your wallet to view your staking overview.')}</Text>
+        </CardBody>
+      </StyledCard>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <StyledCard>
+        <CardBody>
+          <Skeleton height="200px" width="100%" />
+        </CardBody>
+      </StyledCard>
+    )
+  }
+
+  if (visibleCategories.length === 0) {
+    return (
+      <StyledCard>
+        <CardBody>
+          <Text>{t('You have no active staking positions yet.')}</Text>
+        </CardBody>
+      </StyledCard>
+    )
+  }
+
+  return (
+    <Box>
+      {visibleCategories.map((category) => (
+        <StyledCard key={category.key}>
+          <CardHeader>
+            <Heading scale="md">{category.label}</Heading>
+          </CardHeader>
+          <CardBody>
+            {category.positions.map((position) => (
+              <PositionDetails key={position.id} position={position} refreshers={refreshers} />
+            ))}
+          </CardBody>
+        </StyledCard>
+      ))}
+    </Box>
+  )
+}
+
+export default StakedPositionsPanel

--- a/src/views/Nft/market/Profile/components/Overview/index.tsx
+++ b/src/views/Nft/market/Profile/components/Overview/index.tsx
@@ -1,0 +1,49 @@
+import { Box, Flex, Heading, Text } from '@pancakeswap/uikit'
+import { useTranslation } from 'contexts/Localization'
+import useProfileDefiOverview from '../../hooks/useProfileDefiOverview'
+import StakedPositionsPanel from './StakedPositionsPanel'
+import PendingRewardsCard from './PendingRewardsCard'
+
+interface OverviewProps {
+  accountAddress?: string
+}
+
+const ProfileOverview: React.FC<OverviewProps> = ({ accountAddress }) => {
+  const { t } = useTranslation()
+  const { categories, rewardBreakdown, isAccountMatch, isLoading, refreshers, positionsCount } = useProfileDefiOverview(
+    accountAddress,
+  )
+
+  return (
+    <Box>
+      <Heading scale="lg" mb="24px">
+        {t('DeFi overview')}
+      </Heading>
+      {!isAccountMatch ? (
+        <Text color="textSubtle" mb="16px">
+          {t('Connect the wallet that owns this profile to view staking activity and pending rewards.')}
+        </Text>
+      ) : null}
+      <Flex flexDirection={['column', null, 'column', 'row']} gridGap="24px">
+        <Box flex="2">
+          <StakedPositionsPanel
+            categories={categories}
+            isAccountMatch={isAccountMatch}
+            isLoading={isLoading}
+            refreshers={refreshers}
+          />
+        </Box>
+        <Box flex="1">
+          <PendingRewardsCard
+            breakdown={rewardBreakdown}
+            positionsCount={positionsCount}
+            isAccountMatch={isAccountMatch}
+            isLoading={isLoading}
+          />
+        </Box>
+      </Flex>
+    </Box>
+  )
+}
+
+export default ProfileOverview

--- a/src/views/Nft/market/Profile/components/SubMenu.tsx
+++ b/src/views/Nft/market/Profile/components/SubMenu.tsx
@@ -11,6 +11,10 @@ const SubMenuComponent: React.FC = () => {
 
   const ItemsConfig = [
     {
+      label: t('Overview'),
+      href: `${nftsBaseUrl}/profile/${accountAddress}/overview`,
+    },
+    {
       label: t('Items'),
       href: `${nftsBaseUrl}/profile/${accountAddress}`,
     },

--- a/src/views/Nft/market/Profile/hooks/useProfileDefiOverview.ts
+++ b/src/views/Nft/market/Profile/hooks/useProfileDefiOverview.ts
@@ -1,0 +1,429 @@
+import { useCallback, useMemo } from 'react'
+import BigNumber from 'bignumber.js'
+import useWeb3React from 'hooks/useWeb3React'
+import { useAppDispatch } from 'state'
+import { BIG_ZERO } from 'utils/bigNumber'
+import { getAddress } from 'utils/addressHelpers'
+import { ChainId } from '@coincollect/sdk'
+import { useFarms as useNftFarms } from 'state/nftFarms/hooks'
+import { useFarms as useLiquidityFarms, usePriceCakeBusd } from 'state/farms/hooks'
+import { usePools, useVaultPools } from 'state/pools/hooks'
+import { fetchFarmUserDataAsync as fetchNftFarmUserDataAsync } from 'state/nftFarms'
+import { fetchFarmUserDataAsync as fetchLiquidityFarmUserDataAsync } from 'state/farms'
+import { fetchPoolsUserDataAsync, fetchCakeVaultUserData } from 'state/pools'
+import nftFarmsConfig from 'config/constants/nftFarms'
+import { getNftFarmApr, getFarmApr } from 'utils/apr'
+import { VaultKey } from 'state/types'
+import { convertSharesToCake } from 'views/Pools/helpers'
+import tokens from 'config/constants/tokens'
+
+export type OverviewPositionType = 'nftFarm' | 'liquidityFarm' | 'pool' | 'vault'
+
+export interface PendingRewardDetail {
+  token: string
+  amount: BigNumber
+  decimals: number
+}
+
+export interface OverviewPosition {
+  id: string
+  label: string
+  type: OverviewPositionType
+  apr?: number | null
+  aprLabel?: string
+  staked: BigNumber
+  stakedDecimals: number
+  stakingTokenSymbol?: string
+  pendingRewards: PendingRewardDetail[]
+  href?: string
+  pid?: number
+  sousId?: number
+  earningTokenSymbol?: string
+  earningTokenDecimals?: number
+  sideRewards?: any[]
+  earningToken?: any
+}
+
+export interface OverviewCategory {
+  key: 'nftFarms' | 'liquidityFarms' | 'pools' | 'vaults'
+  label: string
+  positions: OverviewPosition[]
+}
+
+export interface RewardBreakdownEntry {
+  token: string
+  amount: BigNumber
+  decimals: number
+}
+
+export interface OverviewRefreshers {
+  nftFarms: () => Promise<void>
+  liquidityFarms: () => Promise<void>
+  pools: () => Promise<void>
+  vaults: () => Promise<void>
+}
+
+export interface ProfileDefiOverviewResult {
+  isLoading: boolean
+  isAccountMatch: boolean
+  categories: OverviewCategory[]
+  rewardBreakdown: RewardBreakdownEntry[]
+  refreshers: OverviewRefreshers
+  refreshAll: () => Promise<void>
+  positionsCount: number
+}
+
+const DEFAULT_REFRESHERS: OverviewRefreshers = {
+  nftFarms: async () => {},
+  liquidityFarms: async () => {},
+  pools: async () => {},
+  vaults: async () => {},
+}
+
+const formatAprDisplay = (apr?: number | null) => {
+  if (apr === null || apr === undefined) {
+    return undefined
+  }
+  if (apr >= 1000) {
+    return `${apr.toFixed(0)}%`
+  }
+  if (apr >= 100) {
+    return `${apr.toFixed(1)}%`
+  }
+  if (apr <= 0) {
+    return '0%'
+  }
+  return `${apr.toFixed(2)}%`
+}
+
+const useProfileDefiOverview = (accountAddress?: string): ProfileDefiOverviewResult => {
+  const { account } = useWeb3React()
+  const dispatch = useAppDispatch()
+  const { data: nftFarms, userDataLoaded: nftFarmsLoaded } = useNftFarms()
+  const { data: liquidityFarms, userDataLoaded: liquidityFarmsLoaded } = useLiquidityFarms()
+  const { pools, userDataLoaded: poolsLoaded } = usePools()
+  const vaultPools = useVaultPools()
+  const cakePrice = usePriceCakeBusd()
+
+  const normalizedAccount = account?.toLowerCase()
+  const normalizedAddress = accountAddress?.toLowerCase()
+  const isAccountMatch = Boolean(normalizedAccount && normalizedAddress && normalizedAccount === normalizedAddress)
+
+  const nftPositions = useMemo<OverviewPosition[]>(() => {
+    if (!isAccountMatch) {
+      return []
+    }
+
+    return nftFarms
+      .map((farm) => {
+        const stakedBalance = farm.userData?.stakedBalance ?? BIG_ZERO
+        const pendingReward = farm.userData?.earnings ?? BIG_ZERO
+
+        if (stakedBalance.eq(0) && pendingReward.eq(0)) {
+          return null
+        }
+
+        const mainCollectionConfig = nftFarmsConfig.find((config) => config.pid === farm.pid)
+        const mainCollectionWeight = mainCollectionConfig?.mainCollectionWeight
+          ? Number(mainCollectionConfig.mainCollectionWeight)
+          : 1
+
+        const totalStaked = farm.totalStaked ?? BIG_ZERO
+        const totalShares = farm.totalShares ?? BIG_ZERO
+        const participantThreshold = farm.participantThreshold ?? 0
+        const isSmartPool = Boolean(farm.contractAddresses)
+        const liquidityBase = isSmartPool ? totalShares.toNumber() : totalStaked.toNumber()
+        const totalLiquidityWithThreshold = new BigNumber(Math.max(liquidityBase, participantThreshold))
+        const { cakeRewardsApr } = getNftFarmApr(
+          new BigNumber(farm.poolWeight),
+          farm.tokenPerBlock ? parseFloat(farm.tokenPerBlock) : null,
+          totalLiquidityWithThreshold,
+          mainCollectionWeight,
+        )
+
+        const collectionAddress = farm.nftAddresses ? getAddress(farm.nftAddresses) : undefined
+        const earnLabel = farm.earningToken ? farm.earningToken.symbol : 'COLLECT'
+
+        return {
+          id: `nft-${farm.pid}`,
+          label: farm.lpSymbol,
+          type: 'nftFarm' as const,
+          apr: cakeRewardsApr,
+          aprLabel:
+            cakeRewardsApr !== null && cakeRewardsApr !== undefined
+              ? `${cakeRewardsApr.toFixed(2)} / day`
+              : undefined,
+          staked: stakedBalance,
+          stakedDecimals: 0,
+          stakingTokenSymbol: farm.lpSymbol,
+          pendingRewards: [
+            {
+              token: earnLabel,
+              amount: pendingReward,
+              decimals: farm.earningToken?.decimals ?? 18,
+            },
+          ],
+          href: collectionAddress ? `/nfts/collections/mint/${collectionAddress}` : undefined,
+          pid: farm.pid,
+          earningTokenSymbol: earnLabel,
+          earningTokenDecimals: farm.earningToken?.decimals ?? 18,
+          sideRewards: farm.sideRewards ?? [],
+          earningToken: farm.earningToken,
+        }
+      })
+      .filter((position): position is OverviewPosition => Boolean(position))
+  }, [isAccountMatch, nftFarms])
+
+  const liquidityPositions = useMemo<OverviewPosition[]>(() => {
+    if (!isAccountMatch) {
+      return []
+    }
+
+    return liquidityFarms
+      .map((farm) => {
+        const stakedBalance = farm.userData?.stakedBalance ?? BIG_ZERO
+        const pendingReward = farm.userData?.earnings ?? BIG_ZERO
+
+        if (stakedBalance.eq(0) && pendingReward.eq(0)) {
+          return null
+        }
+
+        const totalLiquidity = farm.lpTotalInQuoteToken && farm.quoteTokenPriceBusd
+          ? new BigNumber(farm.lpTotalInQuoteToken).times(farm.quoteTokenPriceBusd)
+          : BIG_ZERO
+        const { cakeRewardsApr } = getFarmApr(
+          new BigNumber(farm.poolWeight),
+          cakePrice,
+          totalLiquidity,
+          farm.lpAddresses?.[ChainId.POLYGON],
+        )
+
+        return {
+          id: `farm-${farm.pid}`,
+          label: farm.lpSymbol,
+          type: 'liquidityFarm' as const,
+          apr: cakeRewardsApr,
+          aprLabel: cakeRewardsApr !== null && cakeRewardsApr !== undefined ? formatAprDisplay(cakeRewardsApr) : undefined,
+          staked: stakedBalance,
+          stakedDecimals: 18,
+          stakingTokenSymbol: farm.lpSymbol,
+          pendingRewards: [
+            {
+              token: 'COLLECT',
+              amount: pendingReward,
+              decimals: 18,
+            },
+          ],
+          href: '/farms',
+          pid: farm.pid,
+          earningTokenSymbol: 'COLLECT',
+          earningTokenDecimals: 18,
+        }
+      })
+      .filter((position): position is OverviewPosition => Boolean(position))
+  }, [cakePrice, isAccountMatch, liquidityFarms])
+
+  const poolPositions = useMemo<OverviewPosition[]>(() => {
+    if (!isAccountMatch) {
+      return []
+    }
+
+    return pools
+      .map((pool) => {
+        const stakedBalance = pool.userData?.stakedBalance ?? BIG_ZERO
+        const pendingReward = pool.userData?.pendingReward ?? BIG_ZERO
+
+        if (stakedBalance.eq(0) && pendingReward.eq(0)) {
+          return null
+        }
+
+        const earningToken = pool.earningToken
+        const positionType = pool.vaultKey ? ('vault' as OverviewPositionType) : ('pool' as OverviewPositionType)
+
+        return {
+          id: `${positionType}-${pool.sousId}`,
+          label: pool.earningToken.symbol,
+          type: positionType,
+          apr: pool.apr,
+          aprLabel: pool.apr !== undefined ? formatAprDisplay(pool.apr) : undefined,
+          staked: stakedBalance,
+          stakedDecimals: pool.stakingToken.decimals,
+          stakingTokenSymbol: pool.stakingToken.symbol,
+          pendingRewards: [
+            {
+              token: earningToken.symbol,
+              amount: pendingReward,
+              decimals: earningToken.decimals,
+            },
+          ],
+          href: '/pools',
+          sousId: pool.sousId,
+          earningTokenSymbol: earningToken.symbol,
+          earningTokenDecimals: earningToken.decimals,
+          earningToken,
+        }
+      })
+      .filter((position): position is OverviewPosition => Boolean(position))
+  }, [isAccountMatch, pools])
+
+  const cakeVaultPosition = useMemo<OverviewPosition[]>(() => {
+    if (!isAccountMatch) {
+      return []
+    }
+    const cakeVault = vaultPools[VaultKey.CakeVault]
+    if (!cakeVault) {
+      return []
+    }
+
+    const { userShares, cakeAtLastUserAction, isLoading } = cakeVault.userData
+    if (isLoading || !userShares || userShares.eq(0)) {
+      return []
+    }
+
+    const { cakeAsBigNumber } = convertSharesToCake(userShares, cakeVault.pricePerFullShare)
+    const pendingCake = cakeAsBigNumber.minus(cakeAtLastUserAction)
+
+    if (cakeAsBigNumber.eq(0) && pendingCake.lte(0)) {
+      return []
+    }
+
+    const safePending = pendingCake.gt(0) ? pendingCake : BIG_ZERO
+
+    return [
+      {
+        id: 'vault-cake',
+        label: 'Auto COLLECT',
+        type: 'vault' as const,
+        apr: null,
+        staked: cakeAsBigNumber,
+        stakedDecimals: 18,
+        stakingTokenSymbol: 'COLLECT',
+        pendingRewards: [
+          {
+            token: 'COLLECT',
+            amount: safePending,
+            decimals: 18,
+          },
+        ],
+        href: '/pools',
+        earningTokenSymbol: 'COLLECT',
+        earningTokenDecimals: 18,
+        earningToken: tokens.collect,
+        sousId: 0,
+      },
+    ]
+  }, [isAccountMatch, vaultPools])
+
+  const categorizedPositions = useMemo<OverviewCategory[]>(() => {
+    return [
+      {
+        key: 'nftFarms',
+        label: 'NFT Farms',
+        positions: nftPositions,
+      },
+      {
+        key: 'liquidityFarms',
+        label: 'Liquidity Farms',
+        positions: liquidityPositions,
+      },
+      {
+        key: 'pools',
+        label: 'Pools',
+        positions: poolPositions.filter((position) => position.type === 'pool'),
+      },
+      {
+        key: 'vaults',
+        label: 'Vaults',
+        positions: [
+          ...poolPositions.filter((position) => position.type === 'vault'),
+          ...cakeVaultPosition,
+        ],
+      },
+    ]
+  }, [nftPositions, liquidityPositions, poolPositions, cakeVaultPosition])
+
+  const rewardBreakdown = useMemo<RewardBreakdownEntry[]>(() => {
+    const breakdownMap = new Map<string, RewardBreakdownEntry>()
+
+    categorizedPositions.forEach((category) => {
+      category.positions.forEach((position) => {
+        position.pendingRewards.forEach((reward) => {
+          if (!reward.amount || reward.amount.eq(0)) {
+            return
+          }
+          const existing = breakdownMap.get(reward.token)
+          if (existing) {
+            existing.amount = existing.amount.plus(reward.amount)
+          } else {
+            breakdownMap.set(reward.token, {
+              token: reward.token,
+              amount: reward.amount,
+              decimals: reward.decimals,
+            })
+          }
+        })
+      })
+    })
+
+    return Array.from(breakdownMap.values())
+  }, [categorizedPositions])
+
+  const refreshers: OverviewRefreshers = useMemo(() => {
+    if (!isAccountMatch || !account) {
+      return DEFAULT_REFRESHERS
+    }
+
+    return {
+      nftFarms: async () => {
+        const activePids = nftPositions.map((position) => position.pid).filter((pid): pid is number => pid !== undefined)
+        if (activePids.length === 0) return
+        await dispatch(fetchNftFarmUserDataAsync({ account, pids: activePids }))
+      },
+      liquidityFarms: async () => {
+        const activePids = liquidityPositions
+          .map((position) => position.pid)
+          .filter((pid): pid is number => pid !== undefined)
+        if (activePids.length === 0) return
+        await dispatch(fetchLiquidityFarmUserDataAsync({ account, pids: activePids }))
+      },
+      pools: async () => {
+        await dispatch(fetchPoolsUserDataAsync(account))
+      },
+      vaults: async () => {
+        await dispatch(fetchCakeVaultUserData({ account }))
+      },
+    }
+  }, [account, dispatch, isAccountMatch, nftPositions, liquidityPositions])
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([
+      refreshers.nftFarms(),
+      refreshers.liquidityFarms(),
+      refreshers.pools(),
+      refreshers.vaults(),
+    ])
+  }, [refreshers])
+
+  const isLoading = isAccountMatch &&
+    (!nftFarmsLoaded || !liquidityFarmsLoaded || !poolsLoaded || vaultPools[VaultKey.CakeVault]?.userData?.isLoading)
+
+  const positionsCount = useMemo(
+    () =>
+      categorizedPositions.reduce((acc, category) => {
+        return acc + category.positions.length
+      }, 0),
+    [categorizedPositions],
+  )
+
+  return {
+    isLoading,
+    isAccountMatch,
+    categories: categorizedPositions,
+    rewardBreakdown,
+    refreshers,
+    refreshAll,
+    positionsCount,
+  }
+}
+
+export default useProfileDefiOverview

--- a/src/views/NftFarms/components/FarmCard/HarvestAction.tsx
+++ b/src/views/NftFarms/components/FarmCard/HarvestAction.tsx
@@ -24,9 +24,17 @@ interface FarmCardActionsProps {
   earnLabel?: string
   sideRewards?: any
   earningToken?: Token
+  onHarvestSuccess?: () => void
 }
 
-const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid, earnLabel, sideRewards, earningToken }) => {
+const HarvestAction: React.FC<FarmCardActionsProps> = ({
+  earnings,
+  pid,
+  earnLabel,
+  sideRewards,
+  earningToken,
+  onHarvestSuccess,
+}) => {
   const { account } = useWeb3React()
   const { toastSuccess } = useToast()
   const { fetchWithCatchTxError, loading: pendingTx } = useCatchTxError()
@@ -83,6 +91,7 @@ const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid, earnLabe
               </ToastDescriptionWithTx>,
             )
             dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
+            onHarvestSuccess?.()
           }
         }}
       >

--- a/src/views/Pools/components/PoolCard/Modals/CollectModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/CollectModal.tsx
@@ -33,6 +33,7 @@ interface CollectModalProps {
   isBnbPool: boolean
   isCompoundPool?: boolean
   onDismiss?: () => void
+  onTxSuccess?: () => void
 }
 
 const CollectModal: React.FC<CollectModalProps> = ({
@@ -44,6 +45,7 @@ const CollectModal: React.FC<CollectModalProps> = ({
   isBnbPool,
   isCompoundPool = false,
   onDismiss,
+  onTxSuccess,
 }) => {
   const { t } = useTranslation()
   const { theme } = useTheme()
@@ -70,7 +72,7 @@ const CollectModal: React.FC<CollectModalProps> = ({
       if (shouldCompound) {
         return onStake(fullBalance, earningToken.decimals)
       }
-      
+
       // Harvest
       return onReward()
     })
@@ -93,6 +95,7 @@ const CollectModal: React.FC<CollectModalProps> = ({
       dispatch(updateUserStakedBalance(sousId, account))
       dispatch(updateUserPendingReward(sousId, account))
       dispatch(updateUserBalance(sousId, account))
+      onTxSuccess?.()
       onDismiss?.()
     }
   }


### PR DESCRIPTION
## Summary
- add a reusable DeFi overview hook that aggregates NFT farms, liquidity farms, pools, and vault rewards
- build overview panels for staked positions and pending rewards and expose them via a new profile overview route
- enable profile navigation tabs and extend existing harvest/collect flows to trigger data refresh callbacks

## Testing
- `yarn lint` *(fails: missing @pancakeswap/eslint-config-pancake)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2c2d10288321b9ae760f8351f5b1