### PR TITLE
feat: enhance nft profile holdings

### DIFF
--- a/src/pages/nfts/profile/[accountAddress].tsx
+++ b/src/pages/nfts/profile/[accountAddress].tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import useWeb3React from 'hooks/useWeb3React'
 import { useRouter } from 'next/router'
 import { useProfileForAddress } from 'state/profile/hooks'
@@ -6,6 +7,7 @@ import SubMenu from 'views/Nft/market/Profile/components/SubMenu'
 import UnconnectedProfileNfts from 'views/Nft/market/Profile/components/UnconnectedProfileNfts'
 import UserNfts from 'views/Nft/market/Profile/components/UserNfts'
 import useCoinCollectNftsForAddress from 'views/Nft/market/hooks/useCoinCollectNftsForAddress'
+import useUserStakedNftFarms from 'views/Nft/market/Profile/hooks/useUserStakedNftFarms'
 
 const NftProfilePage = () => {
   const { account } = useWeb3React()
@@ -25,6 +27,15 @@ const NftProfilePage = () => {
     isLoading: isNftLoading,
     refresh: refreshUserNfts,
   } = useCoinCollectNftsForAddress(accountAddress, profile, isProfileFetching)
+  const {
+    stakedFarms,
+    isLoading: isStakedFarmsLoading,
+    totalStakedBalance,
+  } = useUserStakedNftFarms(isConnectedProfile)
+
+  const handleRefreshUserNfts = useCallback(() => {
+    refreshUserNfts()
+  }, [refreshUserNfts])
   
   return (
     <>
@@ -33,12 +44,17 @@ const NftProfilePage = () => {
       */}
       {isConnectedProfile ? (
         <UserNfts
-          nfts={nfts}
-          isLoading={isNftLoading}
-          onSuccessSale={refreshUserNfts}
+          account={account}
+          walletNfts={nfts}
+          isWalletLoading={isNftLoading}
+          stakedFarms={stakedFarms}
+          isStakedLoading={isStakedFarmsLoading}
+          totalStakedBalance={totalStakedBalance}
+          onRefreshWallet={handleRefreshUserNfts}
+          onSuccessSale={handleRefreshUserNfts}
           onSuccessEditProfile={async () => {
             await refreshProfile()
-            refreshUserNfts()
+            handleRefreshUserNfts()
           }}
         />
       ) : (

--- a/src/views/Nft/market/Profile/components/UserNfts.tsx
+++ b/src/views/Nft/market/Profile/components/UserNfts.tsx
@@ -1,7 +1,20 @@
-import { useState, useEffect } from 'react'
-import { Grid, useModal, Text, Flex } from '@pancakeswap/uikit'
+import { useState, useEffect, useMemo, useRef } from 'react'
+import BigNumber from 'bignumber.js'
+import {
+  Box,
+  Button,
+  Flex,
+  Grid,
+  Heading,
+  Spinner,
+  Text,
+  useModal,
+} from '@pancakeswap/uikit'
+import FlexLayout from 'components/Layout/Flex'
 import { NftLocation, NftToken } from 'state/nftMarket/types'
 import { useTranslation } from 'contexts/Localization'
+import formatRewardAmount from 'utils/formatRewardAmount'
+import FarmCard, { NftFarmWithStakedValue } from 'views/NftFarms/components/FarmCard/FarmCard'
 import { CollectibleActionCard } from '../../components/CollectibleCard'
 import GridPlaceholder from '../../components/GridPlaceholder'
 import ProfileNftModal from '../../components/ProfileNftModal'
@@ -9,24 +22,50 @@ import NoNftsImage from '../../components/Activity/NoNftsImage'
 import SellModal from '../../components/BuySellModals/SellModal'
 
 interface ProfileNftProps {
-  nft: NftToken
-  location: NftLocation
+  nft: NftToken | null
+  location: NftLocation | null
 }
 
 interface SellNftProps {
-  nft: NftToken
-  location: NftLocation
-  variant: 'sell' | 'edit'
+  nft: NftToken | null
+  location: NftLocation | null
+  variant: 'sell' | 'edit' | null
 }
 
-const UserNfts: React.FC<{
-  nfts: NftToken[]
-  isLoading: boolean
+interface UserNftsProps {
+  account?: string
+  walletNfts: NftToken[]
+  isWalletLoading: boolean
+  stakedFarms: NftFarmWithStakedValue[]
+  isStakedLoading: boolean
+  totalStakedBalance: BigNumber
+  onRefreshWallet: () => void
   onSuccessSale: () => void
   onSuccessEditProfile: () => void
-}> = ({ nfts, isLoading, onSuccessSale, onSuccessEditProfile }) => {
+}
+
+const getDisplayApr = (apr?: number | null) => {
+  if (apr === undefined || apr === null) {
+    return null
+  }
+
+  return formatRewardAmount(new BigNumber(apr))
+}
+
+const UserNfts: React.FC<UserNftsProps> = ({
+  account,
+  walletNfts,
+  isWalletLoading,
+  stakedFarms,
+  isStakedLoading,
+  totalStakedBalance,
+  onRefreshWallet,
+  onSuccessSale,
+  onSuccessEditProfile,
+}) => {
   const [clickedProfileNft, setClickedProfileNft] = useState<ProfileNftProps>({ nft: null, location: null })
   const [clickedSellNft, setClickedSellNft] = useState<SellNftProps>({ nft: null, location: null, variant: null })
+  const previousStakeAmount = useRef<string | null>(null)
   const [onPresentProfileNftModal] = useModal(
     <ProfileNftModal nft={clickedProfileNft.nft} onSuccess={onSuccessEditProfile} />,
   )
@@ -39,6 +78,18 @@ const UserNfts: React.FC<{
     />,
   )
   const { t } = useTranslation()
+
+  const walletHasNfts = walletNfts.length > 0
+  const walletIsEmpty = walletNfts.length === 0 && !isWalletLoading
+  const poolCount = stakedFarms.length
+
+  const stakedSummaryText = useMemo(() => {
+    if (poolCount === 0) {
+      return t('Track the pools where your NFTs are working for you.')
+    }
+
+    return t('You are staking in %poolCount% NFT pool(s).', { poolCount })
+  }, [poolCount, t])
 
   const handleCollectibleClick = (nft: NftToken, location: NftLocation) => {
     switch (location) {
@@ -72,44 +123,107 @@ const UserNfts: React.FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clickedSellNft])
 
+  useEffect(() => {
+    if (!totalStakedBalance) {
+      return
+    }
+
+    const currentStakeTotal = totalStakedBalance.toString()
+    if (previousStakeAmount.current && previousStakeAmount.current !== currentStakeTotal) {
+      onRefreshWallet()
+    }
+    previousStakeAmount.current = currentStakeTotal
+  }, [totalStakedBalance, onRefreshWallet])
+
   return (
     <>
-      {/* User has no NFTs */}
-      {nfts.length === 0 && !isLoading ? (
-        <Flex p="24px" flexDirection="column" alignItems="center">
-          <NoNftsImage />
-          <Text pt="8px" bold>
-            {t('No NFTs found')}
+      <Box mb="48px">
+        <Flex flexDirection="column" mb="16px">
+          <Heading scale="lg">{t('Unstaked NFTs')}</Heading>
+          <Text mt="8px" color="textSubtle">
+            {walletHasNfts
+              ? t('These NFTs remain in your wallet and are ready to stake or list.')
+              : t('Bring your NFTs here to see them ready for action.')}
           </Text>
         </Flex>
-      ) : // User has NFTs and data has been fetched
-      nfts.length > 0 ? (
-        <Grid
-          gridGap="16px"
-          gridTemplateColumns={['1fr', 'repeat(2, 1fr)', 'repeat(3, 1fr)', null, 'repeat(4, 1fr)']}
-          alignItems="start"
-        >
-          {nfts.map((nft) => {
-            const { marketData, location } = nft
+        {walletIsEmpty ? (
+          <Flex p="24px" flexDirection="column" alignItems="center">
+            <NoNftsImage />
+            <Text pt="8px" bold>
+              {t('No unstaked NFTs found')}
+            </Text>
+          </Flex>
+        ) : walletHasNfts ? (
+          <Grid
+            gridGap="16px"
+            gridTemplateColumns={['1fr', 'repeat(2, 1fr)', 'repeat(3, 1fr)', null, 'repeat(4, 1fr)']}
+            alignItems="start"
+          >
+            {walletNfts.map((nft) => {
+              const { marketData, location } = nft
 
-            return (
-              <CollectibleActionCard
-                isUserNft
-                onClick={() => handleCollectibleClick(nft, location)}
-                key={`${nft.tokenId}-${nft.name}`}
-                nft={nft}
-                currentAskPrice={
-                  marketData?.currentAskPrice && marketData?.isTradable && parseFloat(marketData.currentAskPrice)
-                }
-                nftLocation={location}
+              return (
+                <CollectibleActionCard
+                  isUserNft
+                  onClick={() => handleCollectibleClick(nft, location)}
+                  key={`${nft.tokenId}-${nft.name}`}
+                  nft={nft}
+                  currentAskPrice={
+                    marketData?.currentAskPrice &&
+                    marketData?.isTradable &&
+                    parseFloat(marketData.currentAskPrice)
+                  }
+                  nftLocation={location}
+                />
+              )
+            })}
+          </Grid>
+        ) : (
+          <GridPlaceholder />
+        )}
+      </Box>
+
+      <Box>
+        <Flex flexDirection="column" mb="16px">
+          <Heading scale="lg">{t('Staked NFT Pools')}</Heading>
+          <Text mt="8px" color="textSubtle">
+            {stakedSummaryText}
+          </Text>
+        </Flex>
+        {isStakedLoading ? (
+          <Flex py="40px" flexDirection="column" alignItems="center">
+            <Spinner size={56} color="primary" />
+            <Text mt="16px" color="textSubtle">
+              {t('Loading your NFT pools...')}
+            </Text>
+          </Flex>
+        ) : stakedFarms.length > 0 ? (
+          <FlexLayout>
+            {stakedFarms.map((farm) => (
+              <FarmCard
+                key={farm.pid}
+                farm={farm}
+                displayApr={getDisplayApr(farm.apr)}
+                removed={farm.isFinished}
+                account={account}
               />
-            )
-          })}
-        </Grid>
-      ) : (
-        // User NFT data hasn't been fetched
-        <GridPlaceholder />
-      )}
+            ))}
+          </FlexLayout>
+        ) : (
+          <Flex p="24px" flexDirection="column" alignItems="center" textAlign="center">
+            <NoNftsImage />
+            <Text pt="8px" bold>
+              {t('You are not staking any NFTs yet')}
+            </Text>
+            <Text mt="8px" color="textSubtle" maxWidth="360px">
+              {t('Stake NFTs in a pool to start earning rewards and unlock exclusive perks.')}
+            </Text>
+            <Button as="a" href="/nftpools" mt="16px" variant="primary">
+              {t('Explore NFT Pools')}
+            </Button>
+          </Flex>
+        )}
+      </Box>
     </>
   )
 }

--- a/src/views/Nft/market/Profile/hooks/useUserStakedNftFarms.ts
+++ b/src/views/Nft/market/Profile/hooks/useUserStakedNftFarms.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react'
+import BigNumber from 'bignumber.js'
+import orderBy from 'lodash/orderBy'
+import { BIG_ZERO } from 'utils/bigNumber'
+import { getNftFarmApr } from 'utils/apr'
+import nftFarmsConfig from 'config/constants/nftFarms'
+import { useFarms, usePollFarmsWithUserData } from 'state/nftFarms/hooks'
+import { NftFarmWithStakedValue } from 'views/NftFarms/components/FarmCard/FarmCard'
+
+export interface UseUserStakedNftFarmsResult {
+  stakedFarms: NftFarmWithStakedValue[]
+  totalStakedBalance: BigNumber
+  isLoading: boolean
+}
+
+const useUserStakedNftFarms = (shouldFetch: boolean): UseUserStakedNftFarmsResult => {
+  usePollFarmsWithUserData()
+  const { data: farms, userDataLoaded } = useFarms()
+
+  const { stakedFarms, totalStakedBalance } = useMemo(() => {
+    if (!shouldFetch) {
+      return { stakedFarms: [], totalStakedBalance: BIG_ZERO }
+    }
+
+    const farmsWithPositions: NftFarmWithStakedValue[] = farms
+      .filter((farm) => farm.userData?.stakedBalance && farm.userData.stakedBalance.gt(0))
+      .map((farm) => {
+        const farmConfig = nftFarmsConfig.find((config) => config.pid === farm.pid)
+        const mainCollectionWeight = farmConfig?.mainCollectionWeight
+          ? Number(farmConfig.mainCollectionWeight)
+          : undefined
+
+        const poolWeight = farm.poolWeight ?? BIG_ZERO
+        const tokenPerBlock = farm.tokenPerBlock ? parseFloat(farm.tokenPerBlock) : 0
+        const totalStaked = farm.totalStaked ?? BIG_ZERO
+        const totalShares = farm.totalShares ?? BIG_ZERO
+        const participantThreshold = new BigNumber(farm.participantThreshold ?? 0)
+        const isSmartPool = Boolean(farm.contractAddresses)
+        const effectiveLiquidityBase = isSmartPool ? totalShares : totalStaked
+        const effectiveLiquidity = BigNumber.maximum(participantThreshold, effectiveLiquidityBase)
+
+        const { cakeRewardsApr, lpRewardsApr } = getNftFarmApr(
+          poolWeight,
+          tokenPerBlock,
+          effectiveLiquidity,
+          mainCollectionWeight,
+        )
+
+        return {
+          ...farm,
+          apr: cakeRewardsApr,
+          lpRewardsApr,
+          liquidity: totalStaked,
+        }
+      })
+
+    const orderedFarms = orderBy(
+      farmsWithPositions,
+      [
+        (farm) => (farm.isFinished ? 1 : 0),
+        (farm) => farm.userData?.stakedBalance?.toNumber() ?? 0,
+      ],
+      ['asc', 'desc'],
+    )
+
+    const cumulativeStaked = orderedFarms.reduce(
+      (acc, farm) => acc.plus(farm.userData?.stakedBalance ?? BIG_ZERO),
+      BIG_ZERO,
+    )
+
+    return { stakedFarms: orderedFarms, totalStakedBalance: cumulativeStaked }
+  }, [farms, shouldFetch])
+
+  return {
+    stakedFarms,
+    totalStakedBalance,
+    isLoading: shouldFetch ? !userDataLoaded : false,
+  }
+}
+
+export default useUserStakedNftFarms


### PR DESCRIPTION
## Summary
- display connected wallet NFTs and NFT pool positions directly on the profile page
- add a dedicated hook that aggregates the user’s staked NFT farms with APR and liquidity details
- refresh wallet data when staking balances change and refine empty/loading UI states for a smoother experience

## Testing
- yarn lint *(fails: Yarn 4 in the environment cannot locate the workspace in the existing lockfile)*
- npx eslint 'src/**/*.{js,jsx,ts,tsx}' *(fails: shared config @pancakeswap/eslint-config-pancake not resolvable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcb00738883218b99ae2df3d5df66