### PR TITLE
feat: add onboarding hero to profile dashboard

### DIFF
--- a/src/views/Nft/market/Profile/components/UserNfts.tsx
+++ b/src/views/Nft/market/Profile/components/UserNfts.tsx
@@ -26,6 +26,7 @@ import { groupNftsByCollection, INITIAL_COLLECTION_BATCH, CollectionGroup } from
 import { useClaimInfo } from 'views/Claim/hooks/useClaimInfo'
 import claimConfig from 'config/constants/claim'
 import ClaimCard from 'views/Claim/components/ClaimCard'
+import OnboardingHero from './OnboardingHero'
 
 const REWARD_TOKEN_DECIMALS = new BigNumber(10).pow(18)
 
@@ -241,6 +242,12 @@ const UserNfts: React.FC<UserNftsProps> = ({
 
   return (
     <>
+      <OnboardingHero
+        totalNfts={walletNfts.length}
+        stakedPoolCount={poolCount}
+        claimableCount={claimableClaims.length}
+        walletNfts={walletNfts}
+      />
       <Flex mb="24px" justifyContent="center">
         <ButtonMenu
           scale="sm"


### PR DESCRIPTION
## Summary
- create an animated onboarding hero for the profile dashboard featuring mint, claim, and stake cards
- showcase owned NFTs and playable game NFTs with neon glassmorphism styling
- integrate the hero at the top of the connected profile NFTs experience

## Testing
- yarn lint *(fails: missing @pancakeswap/eslint-config-pancake configuration in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2cbf820883219c8743c24230770b