### PR TITLE
chore: replace deprecated Polygon RPC endpoints with public fallbacks

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -14,7 +14,7 @@ NEXT_PUBLIC_NODE_3 = "https://bsc-dataseed.binance.org"
 # Google Cloud Infrastructure Endpoint - Global
 NEXT_PUBLIC_NODE_PRODUCTION = ""
 
-NEXT_PUBLIC_MATIC_NODE_1 = "https://polygon-rpc.com"
+NEXT_PUBLIC_MATIC_NODE_1 = "https://polygon.drpc.org"
 NEXT_PUBLIC_MUMBAI_NODE_1 = "https://polygon-mumbai-bor.publicnode.com"
 
 NEXT_PUBLIC_GRAPH_API_PROFILE = "https://api.thegraph.com/subgraphs/name/pancakeswap/profile"

--- a/.env.production
+++ b/.env.production
@@ -14,7 +14,7 @@ NEXT_PUBLIC_NODE_3 = "https://bsc-dataseed.binance.org"
 # Google Cloud Infrastructure Endpoint - Global
 NEXT_PUBLIC_NODE_PRODUCTION = ""
 
-NEXT_PUBLIC_MATIC_NODE_1 = "https://polygon-rpc.com"
+NEXT_PUBLIC_MATIC_NODE_1 = "https://polygon.drpc.org"
 NEXT_PUBLIC_MUMBAI_NODE_1 = "https://rpc-mumbai.maticvigil.com"
 
 NEXT_PUBLIC_GRAPH_API_PROFILE = "https://api.thegraph.com/subgraphs/name/pancakeswap/profile"

--- a/src/config/nodes.ts
+++ b/src/config/nodes.ts
@@ -1,10 +1,11 @@
 import { ChainId } from "@coincollect/sdk";
-import { polygon } from "wagmi/chains";
 
 export const PUBLIC_NODES = {
   [ChainId.POLYGON]: [
-    ...polygon.rpcUrls.default.http,
-    'https://polygon-bor-rpc.publicnode.com',
-    'https://polygon.llamarpc.com',
+    "https://polygon.drpc.org",
+    "https://polygon-bor.publicnode.com",
+    "https://1rpc.io/matic",
+    "https://pol.leorpc.com/?api_key=FREE",
+    "https://polygon.llamarpc.com",
   ],
-}
+};

--- a/src/utils/viem.ts
+++ b/src/utils/viem.ts
@@ -60,7 +60,7 @@ export function createViemPublicClientGetter({
   }
 }
 
-const PUBLIC_MAINNET = 'https://polygon-rpc.com'
+const PUBLIC_MAINNET = 'https://polygon.drpc.org'
 
 export const CLIENT_CONFIG = {
   batch: {


### PR DESCRIPTION
### Motivation
- `https://polygon-rpc.com` is no longer reliable and the app needs up-to-date public Polygon RPC endpoints and environment defaults for better resiliency and user experience.
- Provide multiple free/public fallbacks so the app can continue to connect to Polygon when one endpoint becomes unavailable.

### Description
- Replaced the hardcoded/deprecated Polygon mainnet fallback in `src/utils/viem.ts` by changing `PUBLIC_MAINNET` to `https://polygon.drpc.org` used in test-mode fallbacks.
- Replaced the Polygon public list in `src/config/nodes.ts` with a curated fallback list: `https://polygon.drpc.org`, `https://polygon-bor.publicnode.com`, `https://1rpc.io/matic`, `https://pol.leorpc.com/?api_key=FREE`, and `https://polygon.llamarpc.com` and removed the prior dependency on the wagmi `polygon.rpcUrls` array for these defaults.
- Updated environment defaults in `.env.development` and `.env.production` so `NEXT_PUBLIC_MATIC_NODE_1` points to `https://polygon.drpc.org`.
- Kept multiple fallback entries to improve runtime resilience when selecting a Polygon RPC node.

### Testing
- Located all Polygon/RPC references with `rg -n "polygon-rpc|rpc|matic|polygon" .` to confirm impacted files were updated successfully; this search completed successfully.
- Verified file changes by inspecting the diffs of the modified files to ensure the new endpoints were applied correctly.
- Attempted to run `yarn eslint src/config/nodes.ts src/utils/viem.ts`, which failed due to the repository ESLint config package `@pancakeswap/eslint-config-pancake` not being available in this environment, so linting could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69995eb57a4883218d517b5946a37796)